### PR TITLE
Map ';' to ':' in normal mode.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -40,6 +40,9 @@ set hlsearch
 " Exit terminal-job mode
 tmap <Esc><Esc> <C-w>N 
 
+" Enter ex-command mode
+nnoremap ; :
+
 "================="
 " plugin settings "
 "================="


### PR DESCRIPTION
My new laptop has English key board that needs to press shift key to enter ex-command mode. Mapping ';' to ':' improves this annoying action.